### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For Debian/Ubuntu distributions, the following command allows to
 install the necessary packages:
 
 ```bash
-$ sudo apt install debianutils sed make binutils build-essential gcc g++ bash patch gzip bzip2 perl tar cpio unzip rsync file bc git
+$ sudo apt install debianutils sed make binutils build-essential gcc g++ bash patch gzip bzip2 perl tar cpio unzip rsync file bc git libncurses5-dev
 ```
 
 ### Getting the code


### PR DESCRIPTION
Add missing package libncurses5-dev. Needed for menuconfig.

After a fresh install of xubuntu 22.04, I installed the debian packages required to use buildroot but using `make menuconfig` triggered an error that `libncurses5-dev` was missing.

