### PR TITLE
Fix deprecated option hdimage.gpt in image configuration file

### DIFF
--- a/board/stmicroelectronics/stm32mp1/genimage.cfg
+++ b/board/stmicroelectronics/stm32mp1/genimage.cfg
@@ -1,6 +1,6 @@
 image sdcard.img {
 	hdimage {
-		gpt = "true"
+		partition-table-type = "gpt"
 	}
 
 	partition fsbl1 {


### PR DESCRIPTION
During final image creation, the genimage tool outputs the following info message.

`INFO: hdimage(sdcard.img): The option 'gpt' is deprecated. Use 'partition-table-type' instead`

More information on the project's github : https://github.com/pengutronix/genimage#hdimage
