### PR TITLE
Correct the partition number for rootfs

### DIFF
--- a/board/stmicroelectronics/stm32mp1/overlay/boot/extlinux/extlinux.conf
+++ b/board/stmicroelectronics/stm32mp1/overlay/boot/extlinux/extlinux.conf
@@ -1,4 +1,4 @@
 label %DTB_NAME%-buildroot
   kernel /boot/zImage
   devicetree /boot/%DTB_NAME%.dtb
-  append root=/dev/mmcblk0p4 rootwait
+  append root=/dev/mmcblk0p5 rootwait


### PR DESCRIPTION
Updated the partition number of the root filesystem. After introducing the u-boot-env partition in genimage.cfg, the root filesystem could not mount due to an incorrect partition number.

[    2.373989] b300        15558144 mmcblk0 
[    2.374000]  driver: mmcblk
[    2.380859]   b301             216 mmcblk0p1 fab2539d-8fb5-47a8-a90f-676544132344
[    2.380874] 
[    2.389826]   b302             216 mmcblk0p2 eba4948f-5c0a-4228-abee-ad0259fb7b57
[    2.389839] 
[    2.398790]   b303            1558 mmcblk0p3 fae1edb5-642c-41d3-8c85-001b46e68812
[    2.398803] 
[    2.407618]   b304            2048 mmcblk0p4 370b6b61-116c-43c6-ac51-ec471e2a5d55
[    2.407629] 
[    2.416595]   b305          122880 mmcblk0p5 ddd2d7da-33b7-427b-9d27-e01ad2c6557f
[    2.416609] 
[    2.425557] No filesystem could mount root, tried: 
[    2.425564]  ext3
[    2.430445]  ext2
[    2.432382]  ext4
[    2.434317]  squashfs
[    2.436151]  vfat
[    2.438490]  msdos
[    2.438810] usb 1-1: new high-speed USB device number 2 using ehci-platform
[    2.440327]  ntfs
[    2.449373] 
[    2.452740] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(179,4)
[    2.461143] CPU: 1 PID: 1 Comm: swapper/0 Not tainted 6.1.28 #1
[    2.467022] Hardware name: STM32 (Device Tree Support)
