### PR TITLE
build using buildroot as submodule

### DIFF
--- a/.github/workflows/README
+++ b/.github/workflows/README
@@ -3,31 +3,29 @@ Here is the procedure to reproduce the Starter Package for this
 
 1. Clone the repositories:
 
-   git clone git@github.com:bootlin/buildroot
-   git -C buildroot checkout #BR_REV#
-   git clone git@github.com:bootlin/buildroot-external-st.git
+   git clone --recursive git@github.com:bootlin/buildroot-external-st.git
    git -C buildroot-external-st checkout #BR_EXT_REV#
 
 2. Configure Buildroot
 
-   make -C buildroot BR2_EXTERNAL=../buildroot-external-st O=../output #CONFIG#_defconfig
+   make -C buildroot-external-st O=../output #CONFIG#_defconfig
 
 3. Build the #CONFIG# image
 
-   make -C buildroot O=../output
+   make -C buildroot-external-st O=../output
 
 4. Generate license compliance information
 
-   make -C buildroot O=../output legal-info
+   make -C buildroot-external-st O=../output legal-info
 
 5. Build the SDK
 
-   make -C buildroot O=../output sdk
+   make -C buildroot-external-st O=../output sdk
 
 You will find the #CONFIG# image and sdk in:
 
-  buildroot/output/images
+  output/images
 
 You will find the #CONFIG# licenses and sources in:
 
-  buildroot/output/legal-info
+  output/legal-info

--- a/.github/workflows/buildroot-external-st.yml
+++ b/.github/workflows/buildroot-external-st.yml
@@ -10,12 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          submodules: 'true'
           path: buildroot-external-st
-      - uses: actions/checkout@v5
-        with:
-          repository: bootlin/buildroot
-          ref: ${{ env.repo_version }}
-          path: buildroot
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -24,15 +20,15 @@ jobs:
       - name: Register to b2
         run: b2 authorize_account ${{ secrets.B2_KEY_ID }} ${{ secrets.B2_APPLICATION_KEY }}
       - name: Configure Buildroot
-        run: make -C buildroot BR2_EXTERNAL=../buildroot-external-st O=../output ${{ matrix.config }}_defconfig
+        run: make -C buildroot-external-st O=../output ${{ matrix.config }}_defconfig
       - name: Build Buildroot
-        run: make -C buildroot O=../output
+        run: make -C buildroot-external-st O=../output
       - name: Store image
         run: |
              b2 file upload bootlin-buildroot-st output/images/sdcard.img.gz ${{ github.ref_name }}/sdcard-${{ matrix.config }}.img.gz
              b2 file upload bootlin-buildroot-st output/images/sdcard.img.bmap ${{ github.ref_name }}/sdcard-${{ matrix.config }}.img.bmap
       - name: Build SDK
-        run: make -C buildroot O=../output sdk
+        run: make -C buildroot-external-st O=../output sdk
       - name: Store SDK
         run: b2 file upload bootlin-buildroot-st output/images/*_sdk-buildroot.tar.gz ${{ github.ref_name }}/arm-buildroot-linux-gnueabihf_sdk-${{ matrix.config }}.tar.gz
       - name: Generate legal-info

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "buildroot"]
+	path = buildroot
+	url = https://github.com/bootlin/buildroot.git
+	branch = st/2025.02.5

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Adapted Makefile for Buildroot External
+# based on mkmakefile output
+ifeq ("$(origin V)", "command line")
+VERBOSE := $(V)
+endif
+ifneq ($(VERBOSE),1)
+Q := @
+endif
+
+# path to Buildroot and output directory
+BUILDROOT_DIR := $(CURDIR)/buildroot
+OUTPUT_DIR := $(CURDIR)/output
+
+# Verify Buildroot exists
+ifeq (,$(wildcard $(BUILDROOT_DIR)/Makefile))
+$(error BUILDROOT_DIR '$(BUILDROOT_DIR)' is missing or invalid)
+endif
+
+# Construct Make arguments
+MAKEARGS := -C $(BUILDROOT_DIR)
+MAKEARGS += O=$(OUTPUT_DIR)
+MAKEARGS += BR2_EXTERNAL=$(CURDIR)
+
+MAKEFLAGS += --no-print-directory
+
+# Filter Makefile from goals (to avoid infinite loop)
+all_targets := $(filter-out Makefile,$(MAKECMDGOALS))
+
+.PHONY: _all
+
+_all:
+	$(Q)umask 0022 && $(MAKE) $(MAKEARGS) $(all_targets)
+
+# Forward targets like `make menuconfig`, `make linux`, etc.
+$(all_targets): _all
+	@:
+
+# Catch any directory-style targets like `foo/`
+%/: _all
+	@:

--- a/README.md
+++ b/README.md
@@ -213,14 +213,7 @@ Please see the [corresponding manual section](https://buildroot.org/downloads/ma
 ### Getting the code
 
 This `BR2_EXTERNAL` tree is designed to work with the `2025.02.x` LTS
-version of Buildroot. However, we needed a few changes on top of
-upstream Buildroot, so you need to use our own Buildroot fork together
-with this `BR2_EXTERNAL` tree, and more precisely its `st/2025.02.5`
-branch.
-
-```bash
-$ git clone -b st/2025.02.5 https://github.com/bootlin/buildroot.git
-```
+version of Buildroot.
 
 See our documentation on [internal details](docs/internals.md) for more
 information about the changes we have compared to upstream Buildroot.
@@ -228,10 +221,10 @@ information about the changes we have compared to upstream Buildroot.
 Now, clone the matching branch of the `BR2_EXTERNAL` tree:
 
 ```bash
-$ git clone -b st/2025.02.5 https://github.com/bootlin/buildroot-external-st.git
+$ git clone -b st/2025.02.5 --recursive  https://github.com/bootlin/buildroot-external-st.git
 ```
 
-You now have side-by-side a `buildroot` directory and a
+You now have side-by-side a `buildroot` subdirectory as submodule in
 `buildroot-external-st` directory.
 
 ### Configure and build
@@ -239,22 +232,20 @@ You now have side-by-side a `buildroot` directory and a
 Go to the Buildroot directory:
 
 ```bash
-$ cd buildroot/
+$ cd buildroot-external-st/
 ```
 
 And then, configure the system you want to build by using one of the 14
 *defconfigs* provided in this `BR2_EXTERNAL` tree. For example:
 
 ```bash
-buildroot/ $ make BR2_EXTERNAL=../buildroot-external-st st_stm32mp157f_dk2_defconfig
+buildroot-external-st/ $ make st_stm32mp157f_dk2_defconfig
 ```
 
 We are passing two informations to `make`:
 
-1. The path to `BR2_EXTERNAL` tree, which we have cloned side-by-side
-to the Buildroot repository
 
-2. The name of the Buildroot configuration we want to build.
+1. The name of the Buildroot configuration we want to build.
 
 If you want to further customize the Buildroot configuration, you can
 now run `make menuconfig`, but for your first build, we recommend you
@@ -264,7 +255,7 @@ everything is working for you.
 Start the build:
 
 ```bash
-buildroot/ $ make
+buildroot-external-st/ $ make
 ```
 
 This will automaticaly download and build the entire Linux system for
@@ -282,7 +273,7 @@ prebuilt images downloaded from the [starter package section](#Starter-package).
 Flash this image on a SD card:
 
 ```bash
-buildroot/ $ gzip -dc sdcard.img.gz | dd of=/dev/sdX bs=1M
+buildroot-external-st/ $ gzip -dc sdcard.img.gz | dd of=/dev/sdX bs=1M
 ```
 
 You can also use the block map image file to accelerate the flashing
@@ -295,7 +286,7 @@ Note: bmaptool will not erase empty partition like the U-boot environment
 partition.
 
 ```bash
-buildroot/ $ bmaptool copy sdcard.img.gz /dev/sdbX
+buildroot-external-st/ $ bmaptool copy sdcard.img.gz /dev/sdbX
 ```
 
 (Note: this assumes your SD card appears as `/dev/sdX` on your system.)


### PR DESCRIPTION
this allow using _buildroot-external-st_ as standalone repo containing buildroot as submodule
and Makefile triggering the Build to simplify the configure/build workflow.