### PR TITLE
add buildroot as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "buildroot"]
+	path = buildroot
+	url = https://github.com/bootlin/buildroot.git
+	branch = st/2025.02.5

--- a/README.md
+++ b/README.md
@@ -214,39 +214,34 @@ Please see the [corresponding manual section](https://buildroot.org/downloads/ma
 
 This `BR2_EXTERNAL` tree is designed to work with the `2025.02.x` LTS
 version of Buildroot. However, we needed a few changes on top of
-upstream Buildroot, so you need to use our own Buildroot fork together
+upstream Buildroot, so you will use our own Buildroot fork together
 with this `BR2_EXTERNAL` tree, and more precisely its `st/2025.02.5`
-branch.
+branch. See our documentation on [internal details](docs/internals.md)
+for more information about the changes we have compared to upstream
+Buildroot.
+
+Clone the matching branch of the `BR2_EXTERNAL` tree:
 
 ```bash
-$ git clone -b st/2025.02.5 https://github.com/bootlin/buildroot.git
+$ git clone -b st/2025.02.5 --remote-submodules --recurse-submodules https://github.com/bootlin/buildroot-external-st.git
 ```
 
-See our documentation on [internal details](docs/internals.md) for more
-information about the changes we have compared to upstream Buildroot.
-
-Now, clone the matching branch of the `BR2_EXTERNAL` tree:
-
-```bash
-$ git clone -b st/2025.02.5 https://github.com/bootlin/buildroot-external-st.git
-```
-
-You now have side-by-side a `buildroot` directory and a
-`buildroot-external-st` directory.
+You now have a `buildroot` directory inside `buildroot-external-st`
+directory.
 
 ### Configure and build
 
 Go to the Buildroot directory:
 
 ```bash
-$ cd buildroot/
+$ cd buildroot-external-st/buildroot/
 ```
 
 And then, configure the system you want to build by using one of the 14
 *defconfigs* provided in this `BR2_EXTERNAL` tree. For example:
 
 ```bash
-buildroot/ $ make BR2_EXTERNAL=../buildroot-external-st st_stm32mp157f_dk2_defconfig
+buildroot/ $ make BR2_EXTERNAL=.. st_stm32mp157f_dk2_defconfig
 ```
 
 We are passing two informations to `make`:


### PR DESCRIPTION
We should use power of git submodules to improve user's experience. I always use this approach in my repos, [example](https://github.com/AndreiCherniaev/buildroot_f2fs_qemu_x86_64)